### PR TITLE
Enable automatic Maven Central sync when calling task bintrayPublish

### DIFF
--- a/gradle/publishing-repos.gradle
+++ b/gradle/publishing-repos.gradle
@@ -14,8 +14,10 @@ apply plugin: 'com.jfrog.bintray'
 
 
 ext {
-	bintrayUser = project.hasProperty( 'PERSONAL_BINTRAY_USER' ) ? project.property( 'PERSONAL_BINTRAY_USER' ) : null
-	bintrayKey = project.hasProperty( 'PERSONAL_BINTRAY_API_KEY' ) ? project.property( 'PERSONAL_BINTRAY_API_KEY' ) : null
+	bintrayUser = project.findProperty( 'PERSONAL_BINTRAY_USER' )
+	bintrayKey = project.findProperty( 'PERSONAL_BINTRAY_API_KEY' )
+	sonatypeOssrhUser = project.findProperty( 'SONATYPE_OSSRH_USER' )
+	sonatypeOssrhPassword = project.findProperty( 'SONATYPE_OSSRH_PASSWORD' )
 }
 
 
@@ -58,6 +60,8 @@ bintray {
 			]
 			mavenCentralSync {
 				sync = true
+				user = project.sonatypeOssrhUser
+				password = project.sonatypeOssrhPassword
 			}
 		}
 	}


### PR DESCRIPTION
Copied from https://github.com/hibernate/hibernate-reactive/pull/246

Note you need to call the bintrayPublish task after calling
bintrayUpload, otherwise it won't work.

So you will need to use something like this:

./gradlew bintrayUpload bintrayPublish -P PERSONAL_BINTRAY_USER=... -P PERSONAL_BINTRAY_API_KEY=... -P SONATYPE_OSSRH_USER=... -P SONATYPE_OSSRH_PASSWORD=...